### PR TITLE
Fix not found case

### DIFF
--- a/jpn2roman/jpn2roman.py
+++ b/jpn2roman/jpn2roman.py
@@ -39,9 +39,14 @@ def _extract_data_from_xml(responce):
     row = []
 
     for word in words:
-        surface = word.getElementsByTagName('Surface').item(0).childNodes[0].data
-        furigana = word.getElementsByTagName('Furigana').item(0).childNodes[0].data
-        roman = word.getElementsByTagName('Roman').item(0).childNodes[0].data
+        try:
+            surface = word.getElementsByTagName('Surface').item(0).childNodes[0].data
+            furigana = word.getElementsByTagName('Furigana').item(0).childNodes[0].data
+            roman = word.getElementsByTagName('Roman').item(0).childNodes[0].data
+        except:
+            surface = word.getElementsByTagName('Surface').item(0).childNodes[0].data
+            furigana = surface
+            roman = surface
 
         row.append((surface, furigana, roman))
 

--- a/jpn2roman/tests/test_jpn2roman.py
+++ b/jpn2roman/tests/test_jpn2roman.py
@@ -21,6 +21,20 @@ class TestJpn2roman(unittest.TestCase):
         self.assertEqual(expected_0, results[0])
         self.assertEqual(expected_1, results[1])
 
+    def test_include_space(self):
+        # Get result
+        results = get_roman_from_jpn(u"山田　太郎")
+
+        # Expected
+        expected_0 = (u"山田", u"やまだ", u"yamada")
+        expected_1 = (u"　", u"　", u"　")
+        expected_2 = (u"太郎", u"たろう", u"tarou")
+
+        # Assertion
+        self.assertEqual(expected_0, results[0])
+        self.assertEqual(expected_1, results[1])
+        self.assertEqual(expected_2, results[2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
全角スペース等、値が見つからない場合に、変換をかけずにそのままにするように変更。
